### PR TITLE
Added support for tileable background images

### DIFF
--- a/Controller/MyWindowController.m
+++ b/Controller/MyWindowController.m
@@ -30,6 +30,8 @@
 	
 	//--
 	self.background.backgroundColor = [NSColor colorWithCalibratedHue:0.625 saturation:0.0 brightness:0.82 alpha:1.0];
+//	self.background.imageIsTileable = YES;
+//	self.background.backgroundImage = [NSImage imageNamed:@"dark_popup.png"];
 //	self.background.innerShadow = [NSShadow shadowWithColor:[NSColor colorWithCalibratedHue:0.625 saturation:0.0 brightness:0.0 alpha:0.23]
 //													 offset:NSMakeSize(0.0, 0.0)
 //												 blurRadius:2.0];

--- a/StyledView/MyStyledView.h
+++ b/StyledView/MyStyledView.h
@@ -20,6 +20,7 @@
 @property (nonatomic, retain) NSImage		*inactiveBackgroundImage;
 @property (nonatomic, assign) CGFloat		leftCapWidth;
 @property (nonatomic, assign) CGFloat		topCapHeight;
+@property (nonatomic, assign) BOOL			imageIsTileable;
 
 @property (nonatomic, retain) NSColor		*topEdgeColor;
 @property (nonatomic, retain) NSColor		*topHighlightColor;

--- a/StyledView/MyStyledView.m
+++ b/StyledView/MyStyledView.m
@@ -27,6 +27,7 @@
 @synthesize inactiveBackgroundImage;
 @synthesize leftCapWidth;
 @synthesize topCapHeight;
+@synthesize imageIsTileable;
 @synthesize topEdgeColor;
 @synthesize topHighlightColor;
 @synthesize bottomHighlightColor;
@@ -105,8 +106,22 @@
 	}
 	
 	NSImage *backgroundImageToDraw = isKeyWindow ? self.backgroundImage : self.inactiveBackgroundImage ? : self.backgroundImage;
-	if (backgroundImageToDraw) {		
-		if (self.leftCapWidth != NSNotFound || self.topCapHeight != NSNotFound) {
+	if (backgroundImageToDraw) {
+		if (imageIsTileable == true) {
+			// We're about to mess with the pattern phase. Save the current graphics state first so we can restore it.
+			[[NSGraphicsContext currentContext] saveGraphicsState];
+			
+			// This little trick makes the background pattern appear to draw from the the top-left corner rather than from the bottom-left corner. This is visually important when the view resizes when the window is resized.
+			[[NSGraphicsContext currentContext] setPatternPhase:NSMakePoint([self frame].origin.x,[self frame].size.height)];
+			
+			// Stick the image in a color and fill the view with that color.
+			[[NSColor colorWithPatternImage:backgroundImageToDraw] set];
+			NSRectFill(rect);
+			
+			// Restore the original graphics state.
+			[[NSGraphicsContext currentContext] restoreGraphicsState];
+		}
+		else if (self.leftCapWidth != NSNotFound || self.topCapHeight != NSNotFound) {
 			[backgroundImageToDraw drawInRect:rect withLeftCapWidth:self.leftCapWidth topCapHeight:self.topCapHeight];
 		} else {
 			[backgroundImageToDraw drawInRect:rect fromRect:NSZeroRect operation:NSCompositeSourceOver fraction:1.0];


### PR DESCRIPTION
I've added a property called imageIsTileable, that if set to true will tile the specified background image correctly (from top left corner to the bottom right of the view).

I hope this helps you and other users of your great subclass. Thanks for your work.
